### PR TITLE
Fix build due to protobuf files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 __pycache__/
 .idea/
 
-proto
+**/proto/*_pb2.py
+/proto
 
 *.py[cod]
 *.egg-info

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -9,7 +9,6 @@ WORKDIR /server
 RUN apk --update add git gcc musl-dev libffi-dev openssl-dev protobuf
 RUN git clone https://github.com/jenningsm42/mini-mmo-client.git
 RUN cp -r /server/mini-mmo-client/proto /server
-RUN mkdir -p /server/server/proto
 RUN protoc -I=./proto --python_out=./server/proto ./proto/*
 
 RUN pip install -e . -r requirements.txt

--- a/server/proto/__init__.py
+++ b/server/proto/__init__.py
@@ -1,0 +1,6 @@
+# Workaround for absolute import paths from protobuf
+import os
+import sys
+
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))


### PR DESCRIPTION
The protobuf files were modified in the last PR to have relative
imports, but the .gitignore was setup to not commit any files inside the
server/proto directory - including the required __init__.py for the new
protobuf files.