### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 bcrypt
 click
-pymysql
 protobuf
+pymysql[rsa]
 sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,12 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 asn1crypto==0.24.0        # via cryptography
-bcrypt==3.1.4
-cffi==1.11.5              # via bcrypt, cryptography
-click==6.7
-cryptography==2.3.1       # via pymysql
-idna==2.7                 # via cryptography
-protobuf==3.6.1
+bcrypt==3.1.7
+cffi==1.12.3              # via bcrypt, cryptography
+click==7.0
+cryptography==2.7         # via pymysql
+protobuf==3.8.0
 pycparser==2.19           # via cffi
-pymysql==0.9.2
-six==1.11.0               # via bcrypt, cryptography, protobuf
-sqlalchemy==1.2.12
+pymysql[rsa]==0.9.3
+six==1.12.0               # via bcrypt, cryptography, protobuf
+sqlalchemy==1.3.5


### PR DESCRIPTION
SQLAlchemy <1.3.0 had a minor security vulnerability, rest of
dependencies also upgraded.